### PR TITLE
fix: update Cloudflare deploy workflow and scripts

### DIFF
--- a/.github/workflows/cloudflare-deploy.yaml
+++ b/.github/workflows/cloudflare-deploy.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
         run: pnpm install --no-frozen-lockfile
 
       - name: Build for Cloudflare
-        run: pnpm cloudflare:deploy:ci
+        run: pnpm cloudflare:build:ci
         env:
           NEXT_PUBLIC_REPO: ${{ secrets.NEXT_PUBLIC_REPO }}
           NEXT_PUBLIC_REPO_ID: ${{ secrets.NEXT_PUBLIC_REPO_ID }}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"up-latest": "pnpm up -i -L",
 		"cloudflare:preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
 		"cloudflare:deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
-		"cloudflare:deploy:ci": "CLOUDFLARE_BUILD=true pnpm exec opennextjs-cloudflare build",
+		"cloudflare:build:ci": "CLOUDFLARE_BUILD=true pnpm exec opennextjs-cloudflare build",
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
 	},
 	"dependencies": {


### PR DESCRIPTION
Reduce workflow timeout to 10 minutes and replace deploy:ci with build:ci in both workflow and package.json scripts.

# Description

# Linked Issues

# Preview or Screenshot
